### PR TITLE
Add and fix a bunch of AI ranges and some point visualizations

### DIFF
--- a/ai/caveman.lua
+++ b/ai/caveman.lua
@@ -44,6 +44,17 @@ return Entity_AI:new({
                 return ent.move_state == 4 or ent.move_state == 6
             end,
             label = "Reaggro"
+        },
+        { -- Chat
+            shape = geometry.create_box_shape(0.5, -0.1, 1.5, 0.1),
+            flip_with_ent = true,
+            is_visible = function(ent)
+                return ent.move_state == 0 or ent.move_state == 1
+            end,
+            is_active = function(ent)
+                return ent.cooldown_timer == 0
+            end,
+            label = "Chat"
         }
     }
 })

--- a/ai/caveman.lua
+++ b/ai/caveman.lua
@@ -49,7 +49,7 @@ return Entity_AI:new({
             shape = geometry.create_box_shape(0.5, -0.1, 1.5, 0.1),
             flip_with_ent = true,
             is_visible = function(ent)
-                return ent.move_state == 0 or ent.move_state == 1
+                return (ent.move_state == 0 or ent.move_state == 1) and not ai_common.is_mounted(ent)
             end,
             is_active = function(ent)
                 return ent.cooldown_timer == 0

--- a/ai/common.lua
+++ b/ai/common.lua
@@ -173,6 +173,7 @@ function module.create_chaser_no_jump_range(attack_move_state)
         end,
         is_active = function(ent)
             -- TODO: Is this based on standing_on_uid or stand_counter?
+            -- ANSWER: Yes, it's based on standing_on_uid (+ the existence of that entity).
             return ent.standing_on_uid ~= -1
         end,
         label = "No jump"

--- a/ai/flying_fish.lua
+++ b/ai/flying_fish.lua
@@ -3,6 +3,12 @@ return Entity_AI:new({
     id = "flying_fish",
     name = "Flying fish",
     ent_type = ENT_TYPE.MONS_FISH,
+    preprocess = function(ent, ctx)
+        ctx.offsetx = ent.offsetx
+        ctx.offsety = ent.offsety
+        ctx.hitboxx = ent.hitboxx
+        ctx.hitboxy = ent.hitboxy
+    end,
     ranges = {
         { -- Rise
             -- TODO: Ceiling will reduce the height of the rise shape. Getting close may cause a rise even when there is a low ceiling.
@@ -19,6 +25,19 @@ return Entity_AI:new({
             end,
             label = "Attack",
             label_position = LABEL_POSITION.TOP
+        },
+        { -- Stop rising
+            shape = function(ent, ctx)
+                local top_pos = ctx.offsety + ctx.hitboxy + 0.15
+                return geometry.create_point_set_shape(Vec2:new(ctx.offsetx - ctx.hitboxx, top_pos), Vec2:new(0, top_pos), Vec2:new(ctx.offsetx + ctx.hitboxx, top_pos))
+            end,
+            type = Entity_AI.RANGE_TYPE.SOLID_CHECK,
+            is_visible = function(ent)
+                return ent.move_state == 2
+            end,
+            label = "Stop Rising",
+            -- TODO: This hack puts the label above the points.
+            label_position = LABEL_POSITION.BOTTOM
         }
     }
 })

--- a/ai/giant_spider.lua
+++ b/ai/giant_spider.lua
@@ -5,7 +5,7 @@ return Entity_AI:new({
     ranges = {
         { -- Aggro
             -- TODO: Width is controlled by trigger_distance field, which defaults to 0.95 for this entity type.
-            shape = geometry.create_box_shape(-0.95, -7, 0.95, 0),
+            shape = geometry.create_circle_shape(7):clip_box(-0.95, nil, 0.95, 0),
             is_visible = function(ent)
                 return ent.state == CHAR_STATE.HANGING
             end,

--- a/ai/giant_spider.lua
+++ b/ai/giant_spider.lua
@@ -10,6 +10,17 @@ return Entity_AI:new({
                 return ent.state == CHAR_STATE.HANGING
             end,
             label = "Aggro",
+        },
+        { -- Small Jump
+            -- TODO: Width is controlled by trigger_distance field, which defaults to 0.95 for this entity type.
+            shape = geometry.create_box_shape(-1000, -1000, 1000, 0),
+            is_visible = function(ent)
+                return ent.state ~= CHAR_STATE.HANGING and ent.move_state == 0
+            end,
+            is_active = function(ent)
+                return ent.jump_timer == 0
+            end,
+            label = "Small Jump",
         }
     }
 })

--- a/ai/giant_spider.lua
+++ b/ai/giant_spider.lua
@@ -5,14 +5,13 @@ return Entity_AI:new({
     ranges = {
         { -- Aggro
             -- TODO: Width is controlled by trigger_distance field, which defaults to 0.95 for this entity type.
-            shape = geometry.create_circle_shape(7):clip_box(-0.95, nil, 0.95, 0),
+            shape = geometry.create_box_shape(-0.95, -7, 0.95, 0),
             is_visible = function(ent)
                 return ent.state == CHAR_STATE.HANGING
             end,
             label = "Aggro",
         },
         { -- Small Jump
-            -- TODO: Width is controlled by trigger_distance field, which defaults to 0.95 for this entity type.
             shape = geometry.create_box_shape(-1000, -1000, 1000, 0),
             is_visible = function(ent)
                 return ent.state ~= CHAR_STATE.HANGING and ent.move_state == 0

--- a/ai/grub.lua
+++ b/ai/grub.lua
@@ -13,6 +13,28 @@ return Entity_AI:new({
                 return ent.move_state == 0
             end,
             label = "Attack"
+        },
+        { -- Turn to fly (backwall)
+            shape = geometry.create_box_shape(-1, -1, 1, 1),
+            is_visible = function(ent)
+                return ent.move_state == 0 and ent.turn_into_fly_timer ~= -1
+            end,
+            is_active = function(ent)
+                return ent.turn_into_fly_timer == 0
+            end,
+            label = "Turn to fly blockers",
+            label_position = LABEL_POSITION.TOP
+        },
+        { -- Turn to fly (floor)
+            shape = geometry.create_box_shape(-1, 0, 1, 2),
+            is_visible = function(ent)
+                return ent.move_state == 9 and ent.turn_into_fly_timer ~= -1
+            end,
+            is_active = function(ent)
+                return ent.turn_into_fly_timer == 0
+            end,
+            label = "Turn to fly blockers",
+            label_position = LABEL_POSITION.TOP
         }
     }
 })

--- a/ai/hermit_crab.lua
+++ b/ai/hermit_crab.lua
@@ -55,7 +55,6 @@ return Entity_AI:new({
             label = "No hide"
         },
         { -- Bubble (climbing)
-            -- TODO: Not 100% sure about -0.1, but it's pretty close.
             shape = geometry.create_box_shape(-3, -0.1, 3, 3),
             is_visible = function(ent)
                 return ent.state == CHAR_STATE.CLIMBING

--- a/ai/hermit_crab.lua
+++ b/ai/hermit_crab.lua
@@ -10,10 +10,37 @@ return Entity_AI:new({
         local above = get_entities_at(0, MASK.ACTIVEFLOOR | MASK.FLOOR, entx, enty + 1, entlayer, 0.5)
         local left = get_entities_at(0, MASK.ACTIVEFLOOR | MASK.FLOOR, entx - 1, enty, entlayer, 0.5)
         local right = get_entities_at(0, MASK.ACTIVEFLOOR | MASK.FLOOR, entx + 1, enty, entlayer, 0.5)
+        local solid_floor_above = false
+        local solid_floor_left = false
+        local solid_floor_right = false
+        if above then
+            for _, floor in pairs(above) do
+                if test_flag(get_entity(floor).flags, ENT_FLAG.SOLID) then
+                    solid_floor_above = true
+                    break
+                end
+            end
+        end
+        if left then
+            for _, floor in pairs(left) do
+                if test_flag(get_entity(floor).flags, ENT_FLAG.SOLID) then
+                    solid_floor_left = true
+                    break
+                end
+            end
+        end
+        if right then
+            for _, floor in pairs(right) do
+                if test_flag(get_entity(floor).flags, ENT_FLAG.SOLID) then
+                    solid_floor_right = true
+                    break
+                end
+            end
+        end
 
-        ctx.trapped = #left ~= 0 and #right ~= 0
-        ctx.in_cubby_left_opening = #above ~= 0 and # right ~= 0 and #left == 0
-        ctx.in_cubby_right_opening = #above ~= 0 and # left ~= 0 and #right == 0
+        ctx.trapped = solid_floor_left and solid_floor_right
+        ctx.in_cubby_left_opening = solid_floor_above and solid_floor_right and (not solid_floor_left)
+        ctx.in_cubby_right_opening = solid_floor_above and solid_floor_left and (not solid_floor_right)
     end,
     ranges = {
         { -- Emerge

--- a/ai/hundun.lua
+++ b/ai/hundun.lua
@@ -19,6 +19,7 @@ return {
                 end,
                 is_active = function(ent, ctx)
                     -- TODO: Are the X limits based on the level width?
+                    -- ANSWER: Yes, hundun won't move left if its x < 8 (5 from left edge) or right if x > state.width * 10 - 2 (5 from right edge).
                     -- TODO: Hundun can get closer to the sides while walking. I think this is because it uses the same checks to start walking, but then doesn't cut off the walk movement like it does when jumping into the sides.
                     return ent.move_state == 0 and ent.bounce_timer == 0 and not ctx.is_head_attacking and ctx.ent_x >= 8
                 end,
@@ -33,7 +34,7 @@ return {
                 end,
                 is_active = function(ent, ctx)
                     -- TODO: See comments for move left range.
-                    return ent.move_state == 0 and ent.bounce_timer == 0 and not ctx.is_head_attacking and ctx.ent_x <= 28
+                    return ent.move_state == 0 and ent.bounce_timer == 0 and not ctx.is_head_attacking and ctx.ent_x <= state.width * 10 - 2
                 end,
                 label = "Move right",
                 label_position = LABEL_POSITION.LEFT
@@ -57,6 +58,7 @@ return {
                 shape = geometry.create_box_shape(-1000, -1000, 1000, 1000),
                 post_transform_shape = function(ent, ctx, shape)
                     -- TODO: Is this hard-coded, or based on something in the level? Hundun's y_level is an arbitrary value slightly above the spike floor when it's at the top. Seems to be hard-coded based on testing where I moved Hundun further up.
+                    -- ANSWER: Yes, it's hard-coded to 101.5
                     return shape:clip_bottom(101.5)
                 end,
                 is_visible = function(ent)

--- a/ai/lavamander.lua
+++ b/ai/lavamander.lua
@@ -1,3 +1,5 @@
+local HITBOX_H_HALF = get_type(ENT_TYPE.MONS_LAVAMANDER).hitboxx
+
 return Entity_AI:new({
     id = "lavamander",
     name = "Lavamander",
@@ -5,27 +7,16 @@ return Entity_AI:new({
     ranges = {
         { -- Aggro
             -- Once the lavamander sees the player in its aggro range, it will switch to attack mode. It will rise as long as the player is in the attack range, and will attack if it reaches the surface of the lava. It will deaggro after a short time if it isn't able to attack, though it will appear to keep attacking if the player is within the aggro/attack overlap since it immediately reaggros. The first time it surfaces, it will stare at the player for a moment instead of attacking.
-            shape = geometry.create_circle_shape(8),
+            shape = geometry.create_circle_shape(8):clip_box(nil, -1, nil, 4),
             is_visible = function(ent)
                 return ent.is_hot
             end,
             is_active = function(ent)
-                return ent.state == 3 and (ent.move_state == 0 or ent.move_state == 1) and ent.shoot_lava_timer == 0 and ent.chased_target_uid == -1
-            end,
-            label = "Aggro"
-        },
-        { -- Rise and attack
-            shape = geometry.create_box_shape(-1000, -1, 1000, 4),
-            is_visible = function(ent)
-                return ent.is_hot and ent.chased_target_uid >= 0 and ent.shoot_lava_timer == 0
-            end,
-            is_active = function(ent)
-                return (ent.state == 3 or ent.state == CHAR_STATE.FALLING) and (ent.move_state == 0 or ent.move_state == 1)
+                return ent.state == 3 and (ent.move_state == 0 or ent.move_state == 1) and ent.shoot_lava_timer == 0
             end,
             label = function(ent)
                 return ent.player_detect_state == 0 and "Rise and stare" or "Rise and attack"
             end,
-            label_position = LABEL_POSITION.TOP
         },
         { -- Jump
             shape = geometry.create_circle_shape(8):clip_left(0),
@@ -48,6 +39,14 @@ return Entity_AI:new({
                 return ent.state == CHAR_STATE.STANDING and (ent.move_state == 0 or ent.move_state == 1) and ent.jump_pause_timer == 0
             end,
             label = "Turn"
-        }
+        },
+        { -- Lava checks
+            -- Top check is used to stop the lavamander rising during the attack. Both are used to check if the lavamander is in lava and should
+            -- heat/cool.
+            shape = geometry.create_point_set_shape(Vec2:new(0, HITBOX_H_HALF / 2), Vec2:new(0, -HITBOX_H_HALF / 2)),
+            type = Entity_AI.RANGE_TYPE.SOLID_CHECK,
+            label = "Lava Checks",
+            label_position = LABEL_POSITION.BOTTOM
+        },
     }
 })

--- a/ai/lavamander.lua
+++ b/ai/lavamander.lua
@@ -7,16 +7,34 @@ return Entity_AI:new({
     ranges = {
         { -- Aggro
             -- Once the lavamander sees the player in its aggro range, it will switch to attack mode. It will rise as long as the player is in the attack range, and will attack if it reaches the surface of the lava. It will deaggro after a short time if it isn't able to attack, though it will appear to keep attacking if the player is within the aggro/attack overlap since it immediately reaggros. The first time it surfaces, it will stare at the player for a moment instead of attacking.
-            shape = geometry.create_circle_shape(8):clip_box(nil, -1, nil, 4),
+            shape = geometry.create_circle_shape(8),
             is_visible = function(ent)
                 return ent.is_hot
             end,
             is_active = function(ent)
-                return ent.state == 3 and (ent.move_state == 0 or ent.move_state == 1) and ent.shoot_lava_timer == 0
+                return ent.state == 3 and (ent.move_state == 0 or ent.move_state == 1) and ent.shoot_lava_timer == 0 and ent.chased_target_uid == -1
+            end,
+            label = "Aggro",
+            label_position = LABEL_POSITION.TOP,
+        },
+        { -- Rise and attack
+            shape = function(ent)
+                if ent.chased_target_uid == -1 then
+                    return geometry.create_circle_shape(8):clip_box(nil, -1, nil, 4)
+                else
+                    return geometry.create_box_shape(-1000, -1, 1000, 4)
+                end
+            end,
+            is_visible = function(ent)
+                return ent.is_hot and ent.shoot_lava_timer == 0
+            end,
+            is_active = function(ent)
+                return (ent.state == 3 or ent.state == CHAR_STATE.FALLING) and (ent.move_state == 0 or ent.move_state == 1)
             end,
             label = function(ent)
                 return ent.player_detect_state == 0 and "Rise and stare" or "Rise and attack"
             end,
+            label_position = LABEL_POSITION.TOP
         },
         { -- Jump
             shape = geometry.create_circle_shape(8):clip_left(0),

--- a/ai/leprechaun.lua
+++ b/ai/leprechaun.lua
@@ -10,6 +10,18 @@ return Entity_AI:new({
     ranges = {
         ai_common.create_chaser_turn_range(2, "target_in_sight_timer"),
         ai_common.create_chaser_no_jump_range(2),
+        {
+            -- Range in which the leprechaun can jump if there is a tile above an empty space 2 in front of it.
+            shape = geometry.create_box_shape(-1000, -1, 1000, 1000),
+            is_visible = function(ent)
+                return ent.move_state == 2
+            end,
+            is_active = function(ent)
+                return ent.standing_on_uid ~= -1
+            end,
+            label = "Gap Jump",
+            label_position = LABEL_POSITION.BOTTOM,
+        },
         { -- Aggro
             shape = geometry.create_circle_shape(8),
             is_visible = function(ent)

--- a/ai/mech.lua
+++ b/ai/mech.lua
@@ -14,7 +14,7 @@ return Entity_AI:new({
             local rider = get_entity(ent.rider_uid)
             -- gun_cooldown also applies to punching.
             can_attack = (ent.state == CHAR_STATE.STANDING or ent.state == CHAR_STATE.FALLING or (ent.state == CHAR_STATE.DUCKING and ent.move_state == 0))
-                and ent.gun_cooldown == 0 and (rider.type.id == ENT_TYPE.MONS_ALIEN or rider.type.id == ENT_TYPE.MONS_OLMITE_NAKED)
+                and ent.gun_cooldown == 0 and (rider.type.id >= ENT_TYPE.MONS_PET_TUTORIAL and rider.type.id <= ENT_TYPE.MONS_CRITTERSLIME)
         end
         ctx.can_attack = can_attack
     end,

--- a/ai/mole.lua
+++ b/ai/mole.lua
@@ -46,13 +46,9 @@ return Entity_AI:new({
             label = "Emerge"
         },
         { -- Activate
-            shape = geometry.create_circle_shape(16),
-            post_transform_shape = function(ent, ctx)
+            shape = function(ent, ctx)
                 local radius = ctx.trapped and 8 or 16
-                local shape = geometry.create_circle_shape(radius)
-                local x, y = get_position(ent.uid)
-                shape:translate(x, y)
-                return shape
+                return geometry.create_circle_shape(radius)
             end,
             is_visible = function(ent)
                 return ent.move_state == 8 and ent.digging_state == 2

--- a/ai/mole.lua
+++ b/ai/mole.lua
@@ -2,6 +2,36 @@ return Entity_AI:new({
     id = "mole",
     name = "Mole",
     ent_type = ENT_TYPE.MONS_MOLE,
+    preprocess = function(ent, ctx)
+        local entx, enty, entlayer = get_position(ent.uid)
+        local function contains_diggable(floors)
+            local function is_diggable(floor)
+                if floor == -1 then return false end
+                local floor_ent = get_entity(floor)
+                if not floor_ent then return false end
+
+                if not test_flag(floor_ent.flags, ENT_FLAG.SOLID) then return false end
+                if floor_ent.type.search_flags == MASK.ACTIVEFLOOR then return false end
+                if floor_ent.type.id == ENT_TYPE.FLOOR_BORDERTILE then return false end
+                if test_flag(floor_ent.type.properties_flags, 2) then return false end
+                if not test_flag(floor_ent.type.properties_flags, 1) then return false end
+                return true
+            end
+            for _, floor in pairs(floors) do
+                if is_diggable(floor) then
+                    return true
+                end
+            end
+            return false
+        end
+        local here = get_entities_at(0,  MASK.FLOOR, entx, enty, entlayer, 0.5)
+        local above = get_entities_at(0,  MASK.FLOOR, entx, enty + 1, entlayer, 0.5)
+        local left = get_entities_at(0, MASK.FLOOR, entx - 1, enty, entlayer, 0.5)
+        local right = get_entities_at(0, MASK.FLOOR, entx + 1, enty, entlayer, 0.5)
+        local below = get_entities_at(0, MASK.FLOOR, entx, enty - 1, entlayer, 0.5)
+
+        ctx.trapped = contains_diggable(here) and not (contains_diggable(above) or contains_diggable(below) or contains_diggable(left) or contains_diggable(right))
+    end,
     ranges = {
         { -- Emerge
             -- Moles have an erratic countdown_for_appearing variable that decrements every time the mole digs into a new tile, regardless of whether a player is near. If a player is in range while it's at 0, then the mole will move directly towards the player until it either hits air or an undiggable tile. If it hits air, then it emerges. Otherwise, it resets the counter and goes back to digging randomly. If the player moves out of range while it's digging towards them, it will go back to digging randomly, but the counter will stay at 0.
@@ -10,10 +40,24 @@ return Entity_AI:new({
             is_visible = function(ent)
                 return ent.move_state == 9 and ent.digging_state == 2
             end,
-            is_active = function(ent)
-                return ent.countdown_for_appearing == 0
+            is_active = function(ent, ctx)
+                return ent.countdown_for_appearing == 0 or ctx.trapped
             end,
             label = "Emerge"
+        },
+        { -- Activate
+            shape = geometry.create_circle_shape(16),
+            post_transform_shape = function(ent, ctx)
+                local radius = ctx.trapped and 8 or 16
+                local shape = geometry.create_circle_shape(radius)
+                local x, y = get_position(ent.uid)
+                shape:translate(x, y)
+                return shape
+            end,
+            is_visible = function(ent)
+                return ent.move_state == 8 and ent.digging_state == 2
+            end,
+            label = "Active"
         }
     }
 })

--- a/ai/mole.lua
+++ b/ai/mole.lua
@@ -53,7 +53,7 @@ return Entity_AI:new({
             is_visible = function(ent)
                 return ent.move_state == 8 and ent.digging_state == 2
             end,
-            label = "Active"
+            label = "Activate"
         }
     }
 })

--- a/ai/necromancer.lua
+++ b/ai/necromancer.lua
@@ -13,11 +13,26 @@ return Entity_AI:new({
                 -- Back layer necromancers can attack the front layer, but not vice-versa.
                 return ent.layer == LAYER.BACK and LAYER.BOTH or ent.layer
             end,
+            is_visible = function(ent)
+                -- TODO: He can acquire a target while falling and will immediately attack when touching the ground even if the target moves out of range.
+                return ent.move_state == 0 or ent.move_state == 1
+            end,
             is_active = function(ent)
                 -- TODO: He can acquire a target while falling and will immediately attack when touching the ground even if the target moves out of range.
-                return ent.state == CHAR_STATE.STANDING and (ent.move_state == 0 or ent.move_state == 1) and ent.resurrection_timer == 0
+                return ent.state == CHAR_STATE.STANDING and ent.resurrection_timer == 0
             end,
             label = "Attack"
+        },
+        { -- Resurrect
+            shape = geometry.create_box_shape(-8, -8, 8, 8),
+            layer = function(ent)
+                -- Back layer necromancers can attack the front layer, but not vice-versa.
+                return ent.layer == LAYER.BACK and LAYER.BOTH or ent.layer
+            end,
+            is_visible = function(ent)
+                return ent.move_state == 6
+            end,
+            label = "Resurrect"
         }
     }
 })

--- a/ai/olmite.lua
+++ b/ai/olmite.lua
@@ -33,13 +33,8 @@ return Entity_AI:new({
             label_position = LABEL_POSITION.TOP
         },
         { -- Run (corridor check)
-            shape = geometry.create_point_set_shape(Vec2:new(0, 1), Vec2:new(0, 1)),
-            -- TODO: Allow the shape to be a function that takes ent and context?
-            post_transform_shape = function(ent, ctx)
-                local shape = geometry.create_point_set_shape(Vec2:new(ctx.offsetx - ctx.hitboxx, 1), Vec2:new(ctx.offsetx + ctx.hitboxx, 1))
-                local x, y = get_position(ent.uid)
-                shape:translate(x, y)
-                return shape
+            shape = function(ent, ctx)
+                return geometry.create_point_set_shape(Vec2:new(ctx.offsetx - ctx.hitboxx, 1), Vec2:new(ctx.offsetx + ctx.hitboxx, 1))
             end,
             type = Entity_AI.RANGE_TYPE.SOLID_CHECK,
             is_active = function(ent)

--- a/ai/olmite.lua
+++ b/ai/olmite.lua
@@ -3,6 +3,10 @@ return Entity_AI:new({
     id = "olmite",
     name = "Olmite",
     ent_type = { ENT_TYPE.MONS_OLMITE_BODYARMORED, ENT_TYPE.MONS_OLMITE_HELMET, ENT_TYPE.MONS_OLMITE_NAKED },
+    preprocess = function(ent, ctx)
+        ctx.offsetx = ent.offsetx
+        ctx.hitboxx = ent.hitboxx
+    end,
     ranges = {
         { -- Jump
             shape = geometry.create_box_shape(0, -0.4, 3, 0.4),
@@ -27,6 +31,29 @@ return Entity_AI:new({
             end,
             label = "Stomp",
             label_position = LABEL_POSITION.TOP
+        },
+        { -- Run (corridor check)
+            shape = geometry.create_point_set_shape(Vec2:new(0, 1), Vec2:new(0, 1)),
+            -- TODO: Allow the shape to be a function that takes ent and context?
+            post_transform_shape = function(ent, ctx)
+                local shape = geometry.create_point_set_shape(Vec2:new(ctx.offsetx - ctx.hitboxx, 1), Vec2:new(ctx.offsetx + ctx.hitboxx, 1))
+                local x, y = get_position(ent.uid)
+                shape:translate(x, y)
+                return shape
+            end,
+            type = Entity_AI.RANGE_TYPE.SOLID_CHECK,
+            is_active = function(ent)
+                return ent.standing_on_uid ~= -1 and (ent.move_state == 0 or ent.move_state == 1 or ent.move_state == 9)
+            end,
+            label = function(ent)
+                if ent.move_state == 9 then
+                    return "Walk"
+                else
+                    return "Run"
+                end
+            end,
+            -- TODO: This hack puts the label above the points.
+            label_position = LABEL_POSITION.BOTTOM
         }
     }
 })

--- a/ai/olmite.lua
+++ b/ai/olmite.lua
@@ -9,7 +9,7 @@ return Entity_AI:new({
             flip_with_ent = true,
             line_of_sight_checks = 3,
             is_visible = function(ent)
-                return not ent.in_stack
+                return not ent.in_stack and (ent.overlay == nil or ent.overlay.type.id ~= ENT_TYPE.MOUNT_MECH)
             end,
             is_active = function(ent)
                 -- TODO: attack_cooldown_timer is normally 0-60, but breaking an olmite stack can produce an olmite with a timer > 60 that never decrements. An olmite in this state can jump immediately and will fix its timer after landing.

--- a/ai/olmite.lua
+++ b/ai/olmite.lua
@@ -3,10 +3,6 @@ return Entity_AI:new({
     id = "olmite",
     name = "Olmite",
     ent_type = { ENT_TYPE.MONS_OLMITE_BODYARMORED, ENT_TYPE.MONS_OLMITE_HELMET, ENT_TYPE.MONS_OLMITE_NAKED },
-    preprocess = function(ent, ctx)
-        ctx.offsetx = ent.offsetx
-        ctx.hitboxx = ent.hitboxx
-    end,
     ranges = {
         { -- Jump
             shape = geometry.create_box_shape(0, -0.4, 3, 0.4),
@@ -34,7 +30,7 @@ return Entity_AI:new({
         },
         { -- Run (corridor check)
             shape = function(ent, ctx)
-                return geometry.create_point_set_shape(Vec2:new(ctx.offsetx - ctx.hitboxx, 1), Vec2:new(ctx.offsetx + ctx.hitboxx, 1))
+                return geometry.create_point_set_shape(Vec2:new(ent.offsetx - ent.hitboxx, 1), Vec2:new(ent.offsetx + ent.hitboxx, 1))
             end,
             type = Entity_AI.RANGE_TYPE.SOLID_CHECK,
             is_active = function(ent)

--- a/ai/pangxie.lua
+++ b/ai/pangxie.lua
@@ -10,6 +10,9 @@ return Entity_AI:new({
             is_active = function(ent)
                 return ent.move_state == 0 or ent.move_state == 1
             end,
+            is_visible = function(ent)
+                return ent.move_state ~= 11
+            end,
             label = "Bubble"
         },
         { -- Claw
@@ -17,6 +20,9 @@ return Entity_AI:new({
             flip_with_ent = true,
             is_active = function(ent)
                 return ent.move_state == 0 or ent.move_state == 1
+            end,
+            is_visible = function(ent)
+                return ent.move_state ~= 11
             end,
             label = "Claw"
         },
@@ -26,7 +32,26 @@ return Entity_AI:new({
             is_active = function(ent)
                 return ent.move_state == 0 or ent.move_state == 1
             end,
+            is_visible = function(ent)
+                return ent.move_state ~= 11
+            end,
             label = "Turn"
+        },
+        { -- Claw Retract
+            shape = geometry.create_box_shape(-1000, -1000, 1000, -1.5),
+            is_visible = function(ent)
+                return ent.move_state == 11
+            end,
+            label = "Retract",
+            label_position = LABEL_POSITION.TOP
+        },
+        { -- Claw Retract
+            shape = geometry.create_box_shape(-1000, 1.5, 1000, 1000),
+            is_visible = function(ent)
+                return ent.move_state == 11
+            end,
+            label = "Retract",
+            label_position = LABEL_POSITION.BOTTOM
         }
     }
 })

--- a/ai/quillback.lua
+++ b/ai/quillback.lua
@@ -38,6 +38,18 @@ return Entity_AI:new({
                 return true
             end,
             label = "Roll"
+        },
+        { -- Stomp
+            shape = geometry.create_box_shape(-1000, -1000, 0, 1000),
+            flip_with_ent = true,
+            is_visible = function(ent)
+                return ent.move_state == 2
+            end,
+            is_active = function(ent)
+                return ent.chased_target_uid ~= -1
+            end,
+            label = "Stomp",
+            label_position = LABEL_POSITION.RIGHT,
         }
     }
 })

--- a/ai/quillback.lua
+++ b/ai/quillback.lua
@@ -15,27 +15,24 @@ return Entity_AI:new({
         { -- Jump
             shape = geometry.create_circle_shape(5):clip_box(0, -2, nil, 2),
             flip_with_ent = true,
-            is_active = function(ent)
-                -- TODO
-                return true
+            is_visible = function(ent)
+                return ent.move_state == 0 or ent.move_state == 1
             end,
             label = "Jump"
         },
         { -- Turn
             shape = geometry.create_circle_shape(5):clip_box(nil, -2, 0, 2),
             flip_with_ent = true,
-            is_active = function(ent)
-                -- TODO
-                return true
+            is_visible = function(ent)
+                return ent.move_state == 0 or ent.move_state == 1
             end,
             label = "Turn"
         },
         { -- Roll
             shape = geometry.create_donut_shape(5, 12):clip_box(0, -2, nil, 2),
             flip_with_ent = true,
-            is_active = function(ent)
-                -- TODO
-                return true
+            is_visible = function(ent)
+                return ent.move_state == 0 or ent.move_state == 1
             end,
             label = "Roll"
         },

--- a/ai/quillback.lua
+++ b/ai/quillback.lua
@@ -40,7 +40,7 @@ return Entity_AI:new({
             shape = geometry.create_box_shape(-1000, -1000, 0, 1000),
             flip_with_ent = true,
             is_visible = function(ent)
-                return ent.move_state == 2
+                return ent.state & 0xfe == 8 -- state 8 or 9
             end,
             is_active = function(ent)
                 return ent.chased_target_uid ~= -1

--- a/ai/spider.lua
+++ b/ai/spider.lua
@@ -5,7 +5,7 @@ return Entity_AI:new({
     ranges = {
         { -- Aggro
             -- TODO: Width is controlled by trigger_distance field, which defaults to 0.4 for this entity type.
-            shape = geometry.create_circle_shape(7):clip_box(-0.95, nil, 0.95, 0),
+            shape = geometry.create_circle_shape(7):clip_box(-0.4, nil, 0.4, 0),
             is_visible = function(ent)
                 return ent.state == CHAR_STATE.HANGING
             end,

--- a/ai/spider.lua
+++ b/ai/spider.lua
@@ -5,7 +5,7 @@ return Entity_AI:new({
     ranges = {
         { -- Aggro
             -- TODO: Width is controlled by trigger_distance field, which defaults to 0.4 for this entity type.
-            shape = geometry.create_box_shape(-0.4, -7, 0.4, 0),
+            shape = geometry.create_circle_shape(7):clip_box(-0.95, nil, 0.95, 0),
             is_visible = function(ent)
                 return ent.state == CHAR_STATE.HANGING
             end,

--- a/ai/spider.lua
+++ b/ai/spider.lua
@@ -5,7 +5,7 @@ return Entity_AI:new({
     ranges = {
         { -- Aggro
             -- TODO: Width is controlled by trigger_distance field, which defaults to 0.4 for this entity type.
-            shape = geometry.create_circle_shape(7):clip_box(-0.4, nil, 0.4, 0),
+            shape = geometry.create_box_shape(-0.4, -7, 0.4, 0),
             is_visible = function(ent)
                 return ent.state == CHAR_STATE.HANGING
             end,

--- a/ai/tiamat.lua
+++ b/ai/tiamat.lua
@@ -7,6 +7,7 @@ return Entity_AI:new({
     ranges = {
         { -- Shoot
             -- TODO: Is this shape based on Tiamat's position, or the level?
+            -- ANSWER: It's based on the position in the level (
             shape = geometry.create_box_shape(-11, -6, 9, 10),
             is_active = function(ent)
                 return ent.move_state == 0 and ent.attack_timer == 0
@@ -22,7 +23,9 @@ return Entity_AI:new({
         },
         { -- Yell hurtbox
             -- TODO: Yell only seems to do damage on its first frame within its entire hurtbox. The hurtbox stays active for a little while afterward, but only applies knockback.
+            -- ANSWER: The transition from move_state 2 to 6 does damage, then during move_state 6 it does knockback only.
             -- TODO: Haven't tested that hurtbox for paste bombs is the same as hurtbox for players.
+            -- ANSWER: Yes, it is the same.
             shape = geometry.create_box_shape(-4.4, -5.25, 4.6, 3.75),
             type = Entity_AI.RANGE_TYPE.HURTBOX,
             is_active = function(ent)

--- a/ai/tiki_man.lua
+++ b/ai/tiki_man.lua
@@ -17,6 +17,17 @@ return Entity_AI:new({
             end,
             -- TODO: Use "Attack" if the tikiman is going to throw a held object.
             label = "Aggro"
+        },
+        { -- Chat
+            shape = geometry.create_box_shape(0.5, -0.1, 1.5, 0.1),
+            flip_with_ent = true,
+            is_visible = function(ent)
+                return ent.move_state == 0 or ent.move_state == 1
+            end,
+            is_active = function(ent)
+                return ent.cooldown_timer == 0
+            end,
+            label = "Chat"
         }
     }
 })

--- a/ai/ufo.lua
+++ b/ai/ufo.lua
@@ -13,6 +13,36 @@ return Entity_AI:new({
                 return ent.move_state == 0 and ent.attack_cooldown_timer == 0
             end,
             label = "Attack"
+        },
+        { -- Rise
+            shape = geometry.create_circle_shape(8):clip_bottom(0),
+            is_visible = function(ent)
+                return ent.move_state ~= 4 and not ent.is_falling
+            end,
+            is_active = function(ent)
+                return ent.move_state == 0
+            end,
+            label = "Rise"
+        },
+        { -- Lower
+            shape = geometry.create_circle_shape(8):clip_top(-4),
+            is_visible = function(ent)
+                return ent.move_state ~= 4 and not ent.is_falling
+            end,
+            is_active = function(ent)
+                return ent.move_state == 0
+            end,
+            label = "Lower"
+        },
+        { -- Stop Rising
+            shape = geometry.create_circle_shape(8):clip_top(-3),
+            is_visible = function(ent)
+                return ent.move_state ~= 4 and ent.is_falling
+            end,
+            is_active = function(ent)
+                return ent.move_state == 0
+            end,
+            label = "Stop Rising"
         }
     }
 })

--- a/ai/witch_doctor.lua
+++ b/ai/witch_doctor.lua
@@ -13,6 +13,7 @@ return {
                 line_of_sight_checks = 6,
                 is_active = function(ent)
                     -- TODO: When can the witch doctor can initiate another attack after just doing one? He can start another attack at some point during the finishing animation from the previous one.
+                    -- ANSWER?: It looks like it is always active, and will spawn a hint entity on its target if the target does not already have one.
                     return true
                 end,
                 label = "Attack"

--- a/ai/witch_doctor.lua
+++ b/ai/witch_doctor.lua
@@ -44,8 +44,7 @@ return {
                     return ent.color.a > 0
                 end,
                 is_active = function(ent)
-                    -- TODO: When does the skull get an active hurtbox?
-                    return true
+                    return ent.color.a >= 1
                 end,
                 label = "Chase",
             },

--- a/ai/witch_doctor.lua
+++ b/ai/witch_doctor.lua
@@ -49,9 +49,8 @@ return {
                 end,
                 label = "Chase",
             },
-            --[[ TODO: This isn't really a range and shouldn't be depicted as one.
             { -- Orbit
-                shape = geometry.create_circle_shape(1.3),
+                shape = geometry.create_donut_shape(1.3, 1.3),
                 translate_shape = function(ent)
                     if ent.witch_doctor_uid >= 0 then
                         local x, y = get_position(ent.witch_doctor_uid)
@@ -63,7 +62,8 @@ return {
                     return ent.color.a > 0 and ent.witch_doctor_uid >= 0
                 end,
                 label = "Orbit",
-            }]]
+                label_position = LABEL_POSITION.TOP,
+            }
         }
     })
 }

--- a/ai/witch_doctor.lua
+++ b/ai/witch_doctor.lua
@@ -16,6 +16,17 @@ return {
                     return true
                 end,
                 label = "Attack"
+            },
+            { -- Chat
+                shape = geometry.create_box_shape(0.5, -0.1, 1.5, 0.1),
+                flip_with_ent = true,
+                is_visible = function(ent)
+                    return ent.move_state == 0 or ent.move_state == 1
+                end,
+                is_active = function(ent)
+                    return ent.cooldown_timer == 0
+                end,
+                label = "Chat"
             }
         }
     }),

--- a/ai/witch_doctor.lua
+++ b/ai/witch_doctor.lua
@@ -40,8 +40,11 @@ return {
                 -- The skull can move when partially transparent, but has no hurtbox unless it's fully opaque.
                 shape = geometry.create_circle_shape(4),
                 is_visible = function(ent)
-                    -- TODO: Is this actually how the game determines whether the skull is active?
-                    return ent.color.a > 0
+                    local witch = get_entity(ent.witch_doctor_uid)
+                    if witch ~= nil then
+                        return witch.stun_timer == 0 and witch.frozen_timer == 0 and not test_flag(witch.flags, ENT_FLAG.DEAD)
+                    end
+                    return false
                 end,
                 is_active = function(ent)
                     return ent.color.a >= 1
@@ -57,8 +60,13 @@ return {
                     end
                 end,
                 is_visible = function(ent)
-                    -- TODO: Is this actually how the game determines whether the skull is active? Does it care if the witch doctor exists?
-                    return ent.color.a > 0 and ent.witch_doctor_uid >= 0
+                    local witch = get_entity(ent.witch_doctor_uid)
+                    return witch ~= nil
+                end,
+                is_active = function(ent)
+                    local witch = get_entity(ent.witch_doctor_uid)
+                    if witch == nil then return false end
+                    return witch.stun_timer == 0 and witch.frozen_timer == 0 and not test_flag(witch.flags, ENT_FLAG.DEAD) and ent.move_state ~= 6
                 end,
                 label = "Orbit",
                 label_position = LABEL_POSITION.TOP,

--- a/ai/yeti_king.lua
+++ b/ai/yeti_king.lua
@@ -41,6 +41,19 @@ return Entity_AI:new({
             end,
             label = "Freeze hurtbox"
         },
+        { -- Active freeze hurtbox
+            -- This is a hitbox overlap check. It's 2 tiles in front of the yeti king's hitbox and its height matches the king's hitbox.
+            shape = function(ent)
+                local damage_range = math.min(1, ent.idle_counter / 15.0) * 2
+                return geometry.create_box_shape(ent.offsetx + ent.hitboxx, ent.offsety - ent.hitboxy, ent.offsetx + ent.hitboxx + damage_range, ent.offsety + ent.hitboxy)
+            end,
+            flip_with_ent = true,
+            type = Entity_AI.RANGE_TYPE.HURTBOX,
+            is_visible = function(ent)
+                return ent.state == CHAR_STATE.ATTACKING and ent.move_state == 11 and ent.current_animation.id == 0x26
+            end,
+            label = " "
+        },
         { -- Ice break hurtbox
             -- This is a hitbox overlap check. He can only break ice tiles that have empty space under them. Left is 1 tile in front of his hitbox, right is 7 tiles in front of his hitbox, bottom is the bottom of his hitbox, and top is 6 tiles above the top of his hitbox. Hitbox padding allows the ice floor below him to break. He cannot break thin ice tiles.
             shape = geometry.create_box_shape(1.525, -0.93, 7.525, 6.45),

--- a/ai/yeti_king.lua
+++ b/ai/yeti_king.lua
@@ -13,8 +13,11 @@ return Entity_AI:new({
             label_position = LABEL_POSITION.TOP
         },
         { -- Punch hurtbox
-            -- TODO: Same comments as yeti queen.
-            shape = geometry.create_box_shape(-0.525, 0.45, 0.525, 1.45),
+            -- Width is the width of the yeti king's hitbox, and the height is 1 tile tall from the top of his hitbox.
+            shape = function(ent)
+                local top = ent.offsety + ent.hitboxy
+                return geometry.create_box_shape(ent.offsetx - ent.hitboxx, top, ent.offsetx + ent.hitboxx, top + 1)
+            end,
             type = Entity_AI.RANGE_TYPE.HURTBOX,
             is_active = function(ent)
                 -- TODO: Same comments as yeti queen.
@@ -32,17 +35,17 @@ return Entity_AI:new({
         },
         { -- Freeze hurtbox
             -- This is a hitbox overlap check. It's 2 tiles in front of the yeti king's hitbox and its height matches the king's hitbox.
-            -- TODO: Shape starts at 0 width and gradually extends to 2 tiles during the attack?
-            shape = geometry.create_box_shape(0.525, -0.93, 2.525, 0.45),
+            shape = function(ent)
+                return geometry.create_box_shape(ent.offsetx + ent.hitboxx, ent.offsety - ent.hitboxy, ent.offsetx + ent.hitboxx + 2, ent.offsety + ent.hitboxy)
+            end,
             flip_with_ent = true,
             type = Entity_AI.RANGE_TYPE.HURTBOX,
             is_active = function(ent)
-                return ent.state == CHAR_STATE.ATTACKING and ent.move_state == 11
+                return false
             end,
             label = "Freeze hurtbox"
         },
         { -- Active freeze hurtbox
-            -- This is a hitbox overlap check. It's 2 tiles in front of the yeti king's hitbox and its height matches the king's hitbox.
             shape = function(ent)
                 local damage_range = math.min(1, ent.idle_counter / 15.0) * 2
                 return geometry.create_box_shape(ent.offsetx + ent.hitboxx, ent.offsety - ent.hitboxy, ent.offsetx + ent.hitboxx + damage_range, ent.offsety + ent.hitboxy)
@@ -56,7 +59,10 @@ return Entity_AI:new({
         },
         { -- Ice break hurtbox
             -- This is a hitbox overlap check. He can only break ice tiles that have empty space under them. Left is 1 tile in front of his hitbox, right is 7 tiles in front of his hitbox, bottom is the bottom of his hitbox, and top is 6 tiles above the top of his hitbox. Hitbox padding allows the ice floor below him to break. He cannot break thin ice tiles.
-            shape = geometry.create_box_shape(1.525, -0.93, 7.525, 6.45),
+            shape = function(ent)
+                local right = ent.offsetx + ent.hitboxx
+                return geometry.create_box_shape(right + 1, ent.offsety - ent.hitboxy, right + 7, ent.offsety + ent.hitboxy + 6)
+            end,
             flip_with_ent = true,
             type = Entity_AI.RANGE_TYPE.HURTBOX,
             is_active = function(ent)

--- a/ai/yeti_queen.lua
+++ b/ai/yeti_queen.lua
@@ -16,11 +16,15 @@ return Entity_AI:new({
             label_position = LABEL_POSITION.TOP
         },
         { -- Punch hurtbox
-            -- TODO: This seems to be a hitbox overlap check. Its width is the width of the yeti queen's hitbox, and the height is exactly tall enough to hit a player whose origin is within the punch trigger box. Not 100% certain about bottom edge.
-            shape = geometry.create_box_shape(-0.525, 0.45, 0.525, 1.45),
+            -- Width is the width of the yeti queen's hitbox, and the heights from the top of her hitbox to 1 tile above.
+            shape = function(ent)
+                local top = ent.offsety + ent.hitboxy
+                return geometry.create_box_shape(ent.offsetx - ent.hitboxx, top, ent.offsetx + ent.hitboxx, top + 1)
+            end,
             type = Entity_AI.RANGE_TYPE.HURTBOX,
             is_active = function(ent)
                 -- TODO: Only seems to deal damage on the first frame. How do I detect this?
+                -- ANSWER: Does it make sense to make it "active" during move_state 7 (the wind-up for the punch)?
                 return ent.move_state == 6
             end,
             label = "Punch hurtbox"

--- a/ai/yeti_queen.lua
+++ b/ai/yeti_queen.lua
@@ -24,7 +24,6 @@ return Entity_AI:new({
             type = Entity_AI.RANGE_TYPE.HURTBOX,
             is_active = function(ent)
                 -- TODO: Only seems to deal damage on the first frame. How do I detect this?
-                -- ANSWER: Does it make sense to make it "active" during move_state 7 (the wind-up for the punch)?
                 return ent.move_state == 6
             end,
             label = "Punch hurtbox"

--- a/main.lua
+++ b/main.lua
@@ -311,11 +311,19 @@ local function process_tracked_entity(id)
 
                 local shapes = {}
                 if range.shape then
-                    table.insert(shapes, range.shape:clone())
+                    if type(range.shape) == "function" then
+                        table.insert(shapes, range.shape(ent, process_ctx))
+                    else
+                        table.insert(shapes, range.shape:clone())
+                    end
                 end
                 if range.shapes then
                     for _, shape in ipairs(range.shapes) do
-                        table.insert(shapes, shape:clone())
+                        if type(shape) == "function" then
+                            table.insert(shapes, shape(ent, process_ctx))
+                        else
+                            table.insert(shapes, shape:clone())
+                        end
                     end
                 end
 


### PR DESCRIPTION
Adds ranges for:
- Chatters chatting (Caveman/Tiki Man/Witch Doctor)
- Grubs turning to flies
- Giant spider small jump
- Leprachaun "special jump"
- Mole activate
- Necromancer resurrection
- Pangxie claw retraction
- Quillback stomp
- UFO rise/lower/stop rising
- Witch doctor skull's orbit

Fixes ranges for:
- Giant spider
- Hermit crab emerging when in a cubby
- Hundun moving right in non-standard level width
- Lavamander aggro
- Mech's rider entity type filter
- Mole emerge when trapped
- Removed olmite jump range while mounted in a mech
- Hid some quillback ranges while not active
- Spider aggro is actually a clipped circle
- Active/visible conditions in witch doctor ranges
- Active part of yeti king's freeze hurtbox
- Yeti king/queen ranges now calculate their hitboxes instead of hardcoding them

Added point checks for:
- Flying fish flying up into a tile
- Olmites in corridors
- Lavamander "am I in lava?" checks

Answered some questions in TODO comments